### PR TITLE
Add driver support for 30xx and 25xx device types

### DIFF
--- a/micro_epsilon_scancontrol_driver/src/driver.cpp
+++ b/micro_epsilon_scancontrol_driver/src/driver.cpp
@@ -140,7 +140,7 @@ namespace scancontrol_driver
         } else if (device_type >= scanCONTROL30xx_25 && device_type <= scanCONTROL30xx_xxx) {
             ROS_INFO_STREAM("The scanCONTROL is a scanCONTROL30xx, with serial number " << config_.serial << ".");
             config_.model = std::string("scanCONTROL30xx");
-        } else if (device_type >= scanCONTROL25xx_25 && device_type <= scanCONTROL25xx_xx) {
+        } else if (device_type >= scanCONTROL25xx_25 && device_type <= scanCONTROL25xx_xxx) {
             ROS_INFO_STREAM("The scanCONTROL is a scanCONTROL25xx, with serial number " << config_.serial << ".");
             config_.model = std::string("scanCONTROL25xx");
         } else {

--- a/micro_epsilon_scancontrol_driver/src/driver.cpp
+++ b/micro_epsilon_scancontrol_driver/src/driver.cpp
@@ -137,6 +137,12 @@ namespace scancontrol_driver
         } else if (device_type >= scanCONTROL29xx_25 && device_type <= scanCONTROL29xx_xxx) {
             ROS_INFO_STREAM("The scanCONTROL is a scanCONTROL29xx, with serial number " << config_.serial << ".");
             config_.model = std::string("scanCONTROL29xx");
+        } else if (device_type >= scanCONTROL30xx_25 && device_type <= scanCONTROL30xx_xxx) {
+            ROS_INFO_STREAM("The scanCONTROL is a scanCONTROL30xx, with serial number " << config_.serial << ".");
+            config_.model = std::string("scanCONTROL30xx");
+        } else if (device_type >= scanCONTROL25xx_25 && device_type <= scanCONTROL25xx_xx) {
+            ROS_INFO_STREAM("The scanCONTROL is a scanCONTROL25xx, with serial number " << config_.serial << ".");
+            config_.model = std::string("scanCONTROL25xx");
         } else {
             ROS_FATAL("The scanCONTROL device is a undefined type.\nPlease contact Micro-Epsilon for a newer SDK or update the driver.");
             goto stop_initialization;


### PR DESCRIPTION
Should fix #16.

This is a quick fix to add support for the newly added 30xx and 25xx device types. A more long term solution would be to check the `device_type` against `TScannerType` defined in `LLTDataTypes.h` of the SDK instead of checking with a hardcoded list of device types. Updating the SDK version should then automatically allows usage of newer device types. 

@rtonnaer could you test this? I will be at SAM|XL Friday morning as I have an appointment that I was not able to reschedule. I can do some more testing with the sensor then if needed. 