### PR TITLE
Updated Micro epsilon SDK and dependencies

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -41,7 +41,7 @@ RUN wget https://github.com/AravisProject/aravis/releases/download/0.8.30/aravis
     meson setup build && \
     cd build && \
     ninja && \
-    checkinstall --pkgname aravis --pkgversion 0.8.30 --requires="libglib2.0-dev, libxml2-dev" ninja install
+    checkinstall --pkgname aravis --pkgversion 0.8.30 --requires="libglib2.0-dev, libxml2-dev, libusb-1.0-0-dev" ninja install
 
 SHELL ["/bin/bash", "-c"]
 RUN wget https://software.micro-epsilon.com/scanCONTROL-Linux-SDK-${SCANCONTROL_SDK_VERSION//./-}.zip -O scanCONTROL-Linux-SDK-${SCANCONTROL_SDK_VERSION//./-}.zip && \

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,6 +1,6 @@
-ARG SCANCONTROL_SDK_VERSION=0.2.5
+ARG SCANCONTROL_SDK_VERSION=1.0.0
 
-FROM ubuntu:bionic AS build
+FROM ubuntu:focal AS build
 
 ARG SCANCONTROL_SDK_VERSION
 ARG DEBIAN_FRONTEND=noninteractive
@@ -13,45 +13,50 @@ RUN apt-get update && \
       gcc \
       git \
       intltool \
-      libglib2.0-dev \
-      libxml2-dev \
-      meson \
+      python3-pip \
+      ninja-build \
       pkg-config \
       unzip \
       wget \
+      libxml2-dev libglib2.0-dev cmake libusb-1.0-0-dev gobject-introspection \
+                 libgtk-3-dev gtk-doc-tools  xsltproc libgstreamer1.0-dev \
+                 libgstreamer-plugins-base1.0-dev libgstreamer-plugins-good1.0-dev \
+                 libgirepository1.0-dev gettext \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget http://ftp.acc.umu.se/pub/GNOME/sources/aravis/0.6/aravis-0.6.4.tar.xz && \
-    tar xfJ aravis-0.6.4.tar.xz && \
-    rm aravis-0.6.4.tar.xz && \
-    cd aravis-0.6.4 && \
-    ./configure && \
-    make && \
-    checkinstall --pkgname aravis --requires="libglib2.0-dev, libxml2-dev" && \
-    ldconfig
+RUN pip3 install meson
+
+RUN wget https://github.com/AravisProject/aravis/releases/download/0.8.30/aravis-0.8.30.tar.xz -O aravis-0.8.30.tar.xz &&\
+    tar xfJ aravis-0.8.30.tar.xz && \
+    rm aravis-0.8.30.tar.xz && \
+    cd aravis-0.8.30 && \
+    meson setup build && \
+    cd build && \
+    ninja && \
+    checkinstall --pkgname aravis --pkgversion 0.8.30 ninja install
 
 SHELL ["/bin/bash", "-c"]
-RUN wget https://software.micro-epsilon.com/scanCONTROL-Linux-SDK-${SCANCONTROL_SDK_VERSION//./-}.zip && \
-    unzip scanCONTROL-Linux-SDK-${SCANCONTROL_SDK_VERSION//./-}.zip && \
+RUN wget https://software.micro-epsilon.com/scanCONTROL-Linux-SDK-${SCANCONTROL_SDK_VERSION//./-}.zip -O scanCONTROL-Linux-SDK-${SCANCONTROL_SDK_VERSION//./-}.zip && \
+    unzip scanCONTROL-Linux-SDK-${SCANCONTROL_SDK_VERSION//./-}.zip -d scanCONTROL-Linux-SDK/ && \
     rm scanCONTROL-Linux-SDK-${SCANCONTROL_SDK_VERSION//./-}.zip && \
-    cd /scanCONTROL\ Linux\ SDK\ ${SCANCONTROL_SDK_VERSION}/libmescan/ && \
+    cd scanCONTROL-Linux-SDK/libmescan/ && \ 
     meson builddir && \
     cd builddir && \
     ninja && \
     checkinstall --pkgname mescan --pkgversion ${SCANCONTROL_SDK_VERSION} --requires="aravis \(\>= 0.6.0\)" ninja install && \
     ldconfig && \
-    cd "/scanCONTROL Linux SDK ${SCANCONTROL_SDK_VERSION}/libllt/" && \
+    cd ../../libllt && \
     meson builddir && \
     cd builddir && \
     ninja && \
     checkinstall --pkgname llt --pkgversion ${SCANCONTROL_SDK_VERSION} --requires="mescan \(\>= ${SCANCONTROL_SDK_VERSION}\),aravis \(\>= 0.6.0\)" ninja install
 
 RUN mkdir /library_pkgs && \
-    mv /aravis-0.6.4/aravis_0.6.4-1_amd64.deb /library_pkgs && \
-    mv "/scanCONTROL Linux SDK ${SCANCONTROL_SDK_VERSION}/libmescan/builddir/mescan_${SCANCONTROL_SDK_VERSION}-1_amd64.deb" /library_pkgs && \
-    mv "/scanCONTROL Linux SDK ${SCANCONTROL_SDK_VERSION}/libllt/builddir/llt_${SCANCONTROL_SDK_VERSION}-1_amd64.deb" /library_pkgs
+    mv /aravis-0.8.30/build/aravis_0.8.30-1_amd64.deb /library_pkgs && \
+    mv "/scanCONTROL-Linux-SDK/libmescan/builddir/mescan_${SCANCONTROL_SDK_VERSION}-1_amd64.deb" /library_pkgs && \
+    mv "/scanCONTROL-Linux-SDK/libllt/builddir/llt_${SCANCONTROL_SDK_VERSION}-1_amd64.deb" /library_pkgs
 
-FROM ros:melodic-ros-core
+FROM ros:noetic-ros-core
 ARG SCANCONTROL_SDK_VERSION
 
 RUN apt-get update && \
@@ -63,6 +68,6 @@ RUN apt-get update && \
 COPY --from=build ["/library_pkgs", "/library_pkgs"]
 
 RUN apt-get update && \
-    apt install -y /library_pkgs/aravis_0.6.4-1_amd64.deb && \
+    apt install -y /library_pkgs/aravis_0.8.30-1_amd64.deb && \
     apt install /library_pkgs/mescan_${SCANCONTROL_SDK_VERSION}-1_amd64.deb && \
     apt install /library_pkgs/llt_${SCANCONTROL_SDK_VERSION}-1_amd64.deb

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -8,23 +8,31 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       checkinstall \
+      cmake \
       debhelper \
       g++ \
       gcc \
+      gettext \
       git \
+      gobject-introspection \
+      gtk-doc-tools \
       intltool \
+      libgirepository1.0-dev \
+      libglib2.0-dev \
+      libgstreamer1.0-dev \
+      libgstreamer-plugins-base1.0-dev \
+      libgstreamer-plugins-good1.0-dev \
+      libgtk-3-dev \
+      libusb-1.0-0-dev \
+      libxml2-dev \
       python3-pip \
       ninja-build \
       pkg-config \
       unzip \
       wget \
-      libxml2-dev libglib2.0-dev cmake libusb-1.0-0-dev gobject-introspection \
-                 libgtk-3-dev gtk-doc-tools  xsltproc libgstreamer1.0-dev \
-                 libgstreamer-plugins-base1.0-dev libgstreamer-plugins-good1.0-dev \
-                 libgirepository1.0-dev gettext \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN pip3 install meson
+      xsltproc \
+    && rm -rf /var/lib/apt/lists/* && \
+    pip3 install meson
 
 RUN wget https://github.com/AravisProject/aravis/releases/download/0.8.30/aravis-0.8.30.tar.xz -O aravis-0.8.30.tar.xz &&\
     tar xfJ aravis-0.8.30.tar.xz && \
@@ -33,7 +41,7 @@ RUN wget https://github.com/AravisProject/aravis/releases/download/0.8.30/aravis
     meson setup build && \
     cd build && \
     ninja && \
-    checkinstall --pkgname aravis --pkgversion 0.8.30 ninja install
+    checkinstall --pkgname aravis --pkgversion 0.8.30 --requires="libglib2.0-dev, libxml2-dev" ninja install
 
 SHELL ["/bin/bash", "-c"]
 RUN wget https://software.micro-epsilon.com/scanCONTROL-Linux-SDK-${SCANCONTROL_SDK_VERSION//./-}.zip -O scanCONTROL-Linux-SDK-${SCANCONTROL_SDK_VERSION//./-}.zip && \
@@ -43,13 +51,13 @@ RUN wget https://software.micro-epsilon.com/scanCONTROL-Linux-SDK-${SCANCONTROL_
     meson builddir && \
     cd builddir && \
     ninja && \
-    checkinstall --pkgname mescan --pkgversion ${SCANCONTROL_SDK_VERSION} --requires="aravis \(\>= 0.6.0\)" ninja install && \
+    checkinstall --pkgname mescan --pkgversion ${SCANCONTROL_SDK_VERSION} --requires="aravis \(\>= 0.8.0\)" ninja install && \
     ldconfig && \
-    cd ../../libllt && \
+    cd /scanCONTROL-Linux-SDK/libllt && \
     meson builddir && \
     cd builddir && \
     ninja && \
-    checkinstall --pkgname llt --pkgversion ${SCANCONTROL_SDK_VERSION} --requires="mescan \(\>= ${SCANCONTROL_SDK_VERSION}\),aravis \(\>= 0.6.0\)" ninja install
+    checkinstall --pkgname llt --pkgversion ${SCANCONTROL_SDK_VERSION} --requires="mescan \(\>= ${SCANCONTROL_SDK_VERSION}\),aravis \(\>= 0.8.0\)" ninja install
 
 RUN mkdir /library_pkgs && \
     mv /aravis-0.8.30/build/aravis_0.8.30-1_amd64.deb /library_pkgs && \
@@ -59,9 +67,10 @@ RUN mkdir /library_pkgs && \
 FROM ros:noetic-ros-core
 ARG SCANCONTROL_SDK_VERSION
 
-RUN apt-get update && \
-    apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends\
       intltool \
+      libglib2.0-dev \
+      libusb-1.0-0-dev \
       pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
@@ -70,4 +79,6 @@ COPY --from=build ["/library_pkgs", "/library_pkgs"]
 RUN apt-get update && \
     apt install -y /library_pkgs/aravis_0.8.30-1_amd64.deb && \
     apt install /library_pkgs/mescan_${SCANCONTROL_SDK_VERSION}-1_amd64.deb && \
-    apt install /library_pkgs/llt_${SCANCONTROL_SDK_VERSION}-1_amd64.deb
+    apt install /library_pkgs/llt_${SCANCONTROL_SDK_VERSION}-1_amd64.deb \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -69,8 +69,6 @@ ARG SCANCONTROL_SDK_VERSION
 
 RUN apt-get update && apt-get install -y --no-install-recommends\
       intltool \
-      libglib2.0-dev \
-      libusb-1.0-0-dev \
       pkg-config \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/industrial_ci_action.yaml
+++ b/.github/workflows/industrial_ci_action.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         env:
-          - {OS_NAME: ubuntu, OS_CODE_NAME: bionic, ROS_DISTRO: melodic, DOCKER_IMAGE: "samxl/scancontrol:latest"}
+          - {OS_NAME: ubuntu, OS_CODE_NAME: focal, ROS_DISTRO: noetic, DOCKER_IMAGE: "samxl/scancontrol:sdk_v1.0.0"}
     env:
       CCACHE_DIR: /github/home/.ccache
     runs-on: ubuntu-latest

--- a/micro_epsilon_scancontrol_driver/CMakeLists.txt
+++ b/micro_epsilon_scancontrol_driver/CMakeLists.txt
@@ -4,12 +4,22 @@ project(micro_epsilon_scancontrol_driver)
 find_package(catkin REQUIRED COMPONENTS roscpp pcl_ros nodelet micro_epsilon_scancontrol_msgs)
 find_package(PkgConfig REQUIRED)
 
-pkg_check_modules(scancontrol REQUIRED glib-2.0 aravis-0.6 mescan llt)
+pkg_check_modules(scancontrol REQUIRED
+  aravis-0.8
+  glib-2.0
+  llt
+  mescan
+)
 
 catkin_package(
   INCLUDE_DIRS include
-  CATKIN_DEPENDS roscpp pcl_ros nodelet micro_epsilon_scancontrol_msgs
-  DEPENDS scancontrol
+  CATKIN_DEPENDS 
+    micro_epsilon_scancontrol_msgs
+    nodelet 
+    pcl_ros 
+    roscpp 
+  DEPENDS 
+    scancontrol
 )
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${scancontrol_INCLUDE_DIRS})


### PR DESCRIPTION
Update the driver and Dockerfile used for build testing to v1.0.0 of the SDK (currently the latest version) for the Micro Epsilon scanCONTROL devices.

Jira issue: [LH2-210](https://samxl.atlassian.net/browse/LH2-210)

## Motivation and Context

The current SDK version (v0.2.5) is outdated and does not support the latest devices. 

## Changes
- Update the Dockerfile to use the latest SDK version
  - Updated scanCONTROL SDK to v1.0.0 
  - Updated Aravis to 0.8.30

## Type of changes

- Breaking change (Updated the docker image to use Ubuntu focal and ros noetic)

## Checklist

- [x] Update version
- [x] Update dependencies
- [x] Test Docker build
