### PR TITLE
Dev environment for scan control driver testing

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -64,12 +64,19 @@ RUN mkdir /library_pkgs && \
     mv "/scanCONTROL-Linux-SDK/libmescan/builddir/mescan_${SCANCONTROL_SDK_VERSION}-1_amd64.deb" /library_pkgs && \
     mv "/scanCONTROL-Linux-SDK/libllt/builddir/llt_${SCANCONTROL_SDK_VERSION}-1_amd64.deb" /library_pkgs
 
-FROM ros:noetic-ros-core
+FROM osrf/ros:noetic-desktop-full
+ARG USER=user
 ARG SCANCONTROL_SDK_VERSION
 
 RUN apt-get update && apt-get install -y --no-install-recommends\
       intltool \
       pkg-config \
+      git \
+      python3-catkin-tools \
+      ros-noetic-rosserial \ 
+      ros-noetic-actionlib-tools \
+      terminator \
+      python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build ["/library_pkgs", "/library_pkgs"]
@@ -78,5 +85,6 @@ RUN apt-get update && \
     apt install -y /library_pkgs/aravis_0.8.30-1_amd64.deb && \
     apt install /library_pkgs/mescan_${SCANCONTROL_SDK_VERSION}-1_amd64.deb && \
     apt install /library_pkgs/llt_${SCANCONTROL_SDK_VERSION}-1_amd64.deb \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* 
 
+USER ${ROS_USER}

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ Run the uninstall script and follow the instruction in the command window:
 #### Building
 
 To build from source, clone the latest version from this repository into your catkin workspace and compile the package using:
-
+	
+	source /opt/ros/noetic/setup.bash
 	cd catkin_ws/src
-	git clone https://github.com/sam-xl/micro_epsilon_scancontrol.git
+	git clone https://github.com/sam-xl/scancontrol.git
 	cd ../
 	catkin build
 
@@ -59,6 +60,14 @@ Run the unit tests with
  -->
 
 ## Usage
+
+Source the build packages from the repo:
+
+    source devel/setup.bash
+
+Set the path for libllt binaries:
+
+    export PATH=$PATH:/usr/lib:/lib:/usr/local/lib
 
 Run the main driver node with:
 


### PR DESCRIPTION
Update the docker image to support building the `scancontrol` package in the container

Jira issue: [LH2-213](https://samxl.atlassian.net/browse/LH2-213)

# Motivation and Context
ROS Noetic is no longer supported on the newer Ubuntu versions. Therefore a docker container is used to build and run the `scancontrol` package on newer Ubuntu version. To build the package the base image needs to be updated to include the build essentials.

# Changes
- Update the ROS image used and dependencies
- Update the usage Instructions

# Type of changes: 
- New feature 

# Checklist
- [x]  Update README