### PR TITLE
Add intensity field to pointcloud

### DIFF
--- a/micro_epsilon_scancontrol_driver/include/micro_epsilon_scancontrol_driver/driver.h
+++ b/micro_epsilon_scancontrol_driver/include/micro_epsilon_scancontrol_driver/driver.h
@@ -27,7 +27,7 @@
 #define MAX_RESOLUTION_COUNT 6
 #define GENERAL_FUNCTION_FAILED -1
 
-#define DEFAULT_FRAME_ID "scancontrol"
+#define DEFAULT_FRAME_ID "laser_frame"
 #define DEFAULT_TOPIC_NAME "scancontrol_pointcloud"
 
 typedef pcl::PointCloud<pcl::PointXYZI> point_cloud_t;
@@ -149,6 +149,7 @@ namespace scancontrol_driver
             std::vector<double> value_x, value_z;
             int lost_values;
             unsigned int lost_profiles;
+            std::vector<unsigned short> maximum_intensity, threshold;
 
             point_cloud_t::Ptr point_cloud_msg;
 


### PR DESCRIPTION
## Description of MR: 
The partial profile data content was changed to include intensity in the field. Based on the work in https://github.com/ipa-mdh/scancontrol/tree/christian/fix_install_with_intensity
> Depends on #38 

## Motivation and Context
Resin flash and inhomogenous surfaces can have varying intensities in a laser scan and it can help to have the maximum intensity as a field in the point cloud. 

## Changes
1. Change partial profile data size and data start to include intensity values
2. Update the point cloud frame id to match with TFs

## Type of changes
* Features
