### PR TITLE
Add service calls to toggle laser

### DIFF
--- a/micro_epsilon_scancontrol_driver/include/micro_epsilon_scancontrol_driver/driver.h
+++ b/micro_epsilon_scancontrol_driver/include/micro_epsilon_scancontrol_driver/driver.h
@@ -103,6 +103,9 @@ namespace scancontrol_driver
             void ServiceGetIdleDuration(
                 const std::shared_ptr<GetDurationRequest> request,
                 std::shared_ptr<GetDurationResponse> response);
+            void ServiceToggleLaserPower(
+                const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                std::shared_ptr<std_srvs::srv::SetBool::Response> response);
             
         private:
             // Profile functions
@@ -138,6 +141,7 @@ namespace scancontrol_driver
             rclcpp::Service<GetDurationSrv>::SharedPtr get_idle_duration_srv;
             rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr invert_z_srv;
             rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr invert_x_srv;
+            rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr toggle_laser_srv;
 
 
 

--- a/micro_epsilon_scancontrol_driver/src/driver.cpp
+++ b/micro_epsilon_scancontrol_driver/src/driver.cpp
@@ -658,6 +658,9 @@ namespace scancontrol_driver
         response->success = !(response->return_code < GENERAL_FUNCTION_OK);
     }  
 
+    /*
+    Service call that can switch the laser on and off
+    */
     void ScanControlDriver::ServiceToggleLaserPower(
                 const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
                 std::shared_ptr<std_srvs::srv::SetBool::Response> response){


### PR DESCRIPTION
This MR adds a service to toggle the laser between on and off states.

## Motivation and Context
The laser often needs to be turned on and off using a client call. For example, this can be needed when an inspection process requires the laser to be turned on only when it comes close to the part.

## Changes

- `driver.h`: Add declaration for the service call
- `driver.cpp`: Add the implementation for the service callback

## Type of changes
- New feature (Non-Breaking change which adds functionality)

## Test Guidelines and Expected Behaviour 
- Connect the laser hardware
- Terminal 1 (in the root directory, assuming you have followed the build instructions in README)
```bash
ros2 run micro_epsilon_scancontrol_driver driver_node
```
- Terminal 2
```bash
ros2 service call /scancontrol_driver_node/toggle_laser std_srvs/SetBool '{data: false}'
```
If everything worked correctly, you should see the laser turn off and on based on the data argument
